### PR TITLE
Updated React to 15.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "lodash": "^4.3.0",
     "mjml": "^2.1.1",
-    "react": "^0.14.7"
+    "react": "^15.4.2"
   },
   "devDependencies": {
     "babel-plugin-transform-decorators-legacy": "^1.3.4",


### PR DESCRIPTION
React ^0.14.7 causes an error.
```
module.js:442
    throw err;
    ^

Error: Cannot find module 'react/lib/ReactComponentTreeHook'
    at Function.Module._resolveFilename (module.js:440:15)
    at Function.Module._load (module.js:388:25)
    at Module.require (module.js:468:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/Users/Jordan/Downloads/mjml-starter-kit-master/node_modules/react-dom/lib/ReactDebugTool.js:16:30)
    at Module._compile (module.js:541:32)
    at Module._extensions..js (module.js:550:10)
    at Object.require.extensions.(anonymous function) [as .js] (/Users/Jordan/Downloads/mjml-starter-kit-master/node_modules/babel-register/lib/node.js:152:7)
    at Module.load (module.js:458:32)
    at tryModuleLoad (module.js:417:12)
```

Simply updating the react package to ^15.4.2 fixes the problem :)